### PR TITLE
gBe more explicit about state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CpuTime
 
-C++17 header only timer library (`clock_gettime` wrapper)
+C++11 header only timer library (`clock_gettime` wrapper)
 
 Allows you to measure
 - Real time spent

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.22)
 project(CpuTimer)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address -fsanitize=undefined -Wall")
 
 enable_testing()

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -3,4 +3,5 @@ find_package(Catch2 3.3.1 REQUIRED CONFIG)
 
 add_executable(TestCpuTimer test.cpp)
 target_link_libraries(TestCpuTimer CpuTimer Catch2::Catch2WithMain)
+set_target_properties(TestCpuTimer PROPERTIES CXX_STANDARD 17)
 add_test(NAME TestCpuTimer COMMAND TestCpuTimer)


### PR DESCRIPTION
Instead of optional start and stop time, manage state in a single enum. This makes the code easier to reason about, and also allows us to compile the library under C++11. (The tests still need 17 though due to Catch2.)

This also made me realise I was missing tests for calling `start()` and `stop()` several times.

Also discovered and fixed a copy-paste bug in the exception message in the "Checking elapsed time without starting throws" test.