### PR TITLE
Custom matcher for time measurements

### DIFF
--- a/src/conanfile.txt
+++ b/src/conanfile.txt
@@ -1,6 +1,7 @@
 [requires]
 catch2/3.3.1
 benchmark/1.7.1
+fmt/9.1.0
 
 [generators]
 CMakeDeps

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -1,9 +1,10 @@
 find_package(Catch2 3.3.1 REQUIRED CONFIG)
+find_package(fmt 9.1.0 REQUIRED CONFIG)
 
 function(add_cpu_timer_test)
     cmake_parse_arguments(ARG "" "NAME" "SOURCES" ${ARGN})
     add_executable(${ARG_NAME} ${ARG_SOURCES})
-    target_link_libraries(${ARG_NAME} CpuTimer Catch2::Catch2WithMain)
+    target_link_libraries(${ARG_NAME} CpuTimer Catch2::Catch2WithMain fmt::fmt)
     set_target_properties(${ARG_NAME} PROPERTIES CXX_STANDARD 17)
     target_include_directories(${ARG_NAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/include")
     add_test(NAME ${ARG_NAME} COMMAND ${ARG_NAME})

--- a/src/test/include/at_least_matcher.h
+++ b/src/test/include/at_least_matcher.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_templated.hpp>
+#include <fmt/format.h>
+
+template <typename T>
+struct AtLeastMatcher : Catch::Matchers::MatcherGenericBase
+{
+    AtLeastMatcher(T atLeast, T tolerance)
+        : m_atLeast{atLeast}, m_tolerance(tolerance)
+    {
+    }
+
+    bool match(T value) const
+    {
+        return value >= m_atLeast && value <= m_atLeast + m_tolerance;
+    }
+
+    std::string describe() const override
+    {
+        return fmt::format("Is at least {}, with absolute tolerance {}",
+                           m_atLeast, m_tolerance);
+    }
+
+  private:
+    T m_atLeast;
+    T m_tolerance;
+};
+
+template <typename T> auto AtLeast(T atLeast, T tolerance) -> AtLeastMatcher<T>
+{
+    return AtLeastMatcher<T>(atLeast, tolerance);
+}


### PR DESCRIPTION
Instead of `WithinAbs` which was not as readable, create a new `AtLeast` matcher which has better semantics for what we actually are interested in testing. Also factor out the tolerance so it can be more easily adjusted.